### PR TITLE
一時的に「WebSocketのURLをDNSではなく直値で見る」ようにする

### DIFF
--- a/aws-infra/global/lib/alws-global-stack.ts
+++ b/aws-infra/global/lib/alws-global-stack.ts
@@ -9,6 +9,7 @@ import { AlwsStackProps } from './alws-stack-props';
 import { Context } from './context/context';
 import { Duration } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { ParameterStore } from './parameterstore/parameter-store';
 
 export class AlwsGlobalStack extends cdk.Stack {
     constructor(scope: Construct, id: string, props?: AlwsStackProps) {
@@ -46,8 +47,9 @@ export class AlwsGlobalStack extends cdk.Stack {
             comment: 'All names that do not exist in the A record are treated as "."'
         });
 
-        this.savePrameterStore(`${settings.systemName()}-hostedzone-id`, hostedZone.hostedZoneId);
-        this.savePrameterStore(`${settings.systemName()}-certification-arn`, certificate.certificateArn);
+        const parameterStore = new ParameterStore(settings, this);
+        parameterStore.registerHostedZoneId(hostedZone.hostedZoneId);
+        parameterStore.registerCerificationArn(certificate.certificateArn);
     }
 
     private buildContainerRepository(settings: Context): ecr.Repository[] {
@@ -97,10 +99,6 @@ export class AlwsGlobalStack extends cdk.Stack {
             }
         });
         repositories.forEach(r => r.grantPullPush(tagBuildOfSourceCIProject.grantPrincipal));
-    }
-
-    private savePrameterStore(key: string, value: string): StringParameter {
-        return new StringParameter(this, key, { stringValue: value });
     }
 
     private setTag(key: string, value: string): void {

--- a/aws-infra/global/lib/context/context.ts
+++ b/aws-infra/global/lib/context/context.ts
@@ -122,14 +122,6 @@ export class Context {
         return this.currentStage().apiFqdn + '.';
     }
 
-    public certArnPraStoreName(): string {
-        return `${this.systemName()}-certification-arn`;
-    }
-
-    public hostedZoneIdPraStoreName(): string {
-        return `${this.systemName()}-hostedzone-id`;
-    }
-
     public dynamoDbTableName(): string {
         return `${this.systemName()}_websocket_connections_${this.currentStageId}`;
     }

--- a/aws-infra/global/lib/parameterstore/parameter-store.ts
+++ b/aws-infra/global/lib/parameterstore/parameter-store.ts
@@ -1,0 +1,45 @@
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { Context } from '../context/context';
+
+export class ParameterStore {
+    constructor(
+        private readonly context: Context,
+        private readonly scope: Construct,
+    ) { }
+
+    public cerificationArn(): string {
+        return this.lookup(this.certArnPraStoreName());
+    }
+
+    public hostedZoneId(): string {
+        return this.lookup(this.hostedZoneIdPraStoreName());
+    }
+
+
+    public registerCerificationArn(value: string): void {
+        this.register(this.certArnPraStoreName(), value);
+    }
+
+    public registerHostedZoneId(value: string): void {
+        this.register(this.hostedZoneIdPraStoreName(), value);
+    }
+
+
+    public certArnPraStoreName(): string {
+        return `${this.context.systemName()}-certification-arn`;
+    }
+
+    public hostedZoneIdPraStoreName(): string {
+        return `${this.context.systemName()}-hostedzone-id`;
+    }
+
+
+    private lookup(parameterName: string): string {
+        return StringParameter.valueFromLookup(this.scope, parameterName);
+    }
+
+    private register(parameterName: string, value: string): StringParameter {
+        return new StringParameter(this.scope, parameterName, { stringValue: value });
+    }
+}

--- a/aws-infra/stage-of/lib/alws-stage-of-stack.ts
+++ b/aws-infra/stage-of/lib/alws-stage-of-stack.ts
@@ -27,6 +27,7 @@ export class AlwsStageOfStack extends cdk.Stack {
             rds: rds.appRds,
             rdsSecret: rds.rdsSecret,
             ecsSecurityGroup: vpc.ecsSecurityGroup,
+            webSocketApiStage: apiAndLambda.webSocketApiStage,
             innerApi: apiAndLambda.innerApi
         });
 

--- a/aws-infra/stage-of/lib/construct/apigateway-and-lambda.ts
+++ b/aws-infra/stage-of/lib/construct/apigateway-and-lambda.ts
@@ -12,7 +12,8 @@ export interface ApiGatewayAndLambdaProps {
 }
 
 export class ApiGatewayAndLambda extends Construct {
-    public innerApi: RestApi;
+    public readonly webSocketApiStage: CfnStage;
+    public readonly innerApi: RestApi;
 
     constructor(scope: Construct, id: string, props: ApiGatewayAndLambdaProps) {
         super(scope, id);
@@ -34,7 +35,7 @@ export class ApiGatewayAndLambda extends Construct {
         });
     }
 
-    private buildWebSocektApiGatewayAndLambda(settings: Context, dynamoDbTable: Table, stack: Stack): void {
+    private buildWebSocektApiGatewayAndLambda(settings: Context, dynamoDbTable: Table, stack: Stack): CfnStage {
         const webSocketApi = new CfnApi(this, settings.wpp('WebSocketApi'), {
             name: settings.wpk('websocket-api'),
             protocolType: 'WEBSOCKET',
@@ -92,7 +93,9 @@ export class ApiGatewayAndLambda extends Construct {
             autoDeploy: true,
             deploymentId: deployment.ref,
             stageName: 'v1',
-        })
+        });
+
+        return stage;
     }
 
     private buildWebSocektApiKickApiGatewayAndLambda(settings: Context, stack: Stack): RestApi {

--- a/aws-infra/stage-of/lib/construct/apigateway-and-lambda.ts
+++ b/aws-infra/stage-of/lib/construct/apigateway-and-lambda.ts
@@ -19,7 +19,7 @@ export class ApiGatewayAndLambda extends Construct {
         super(scope, id);
 
         const dynamoDbTable = this.buildDynamoDbTableOfWebSocketConnection(props.context);
-        this.buildWebSocektApiGatewayAndLambda(props.context, dynamoDbTable, scope as Stack);
+        this.webSocketApiStage = this.buildWebSocektApiGatewayAndLambda(props.context, dynamoDbTable, scope as Stack);
         this.innerApi = this.buildWebSocektApiKickApiGatewayAndLambda(props.context, scope as Stack);
     }
 

--- a/aws-infra/stage-of/lib/construct/apigateway-endpoint.ts
+++ b/aws-infra/stage-of/lib/construct/apigateway-endpoint.ts
@@ -1,0 +1,14 @@
+import { CfnStage } from "aws-cdk-lib/aws-apigatewayv2";
+
+export class ApiGatewayEndpoint {
+    constructor(private readonly apiStage: CfnStage) { }
+
+    public path(): string {
+        const s = this.apiStage;
+        return `${s.apiId}.execute-api.${s.stack.region}.amazonaws.com/${s.stageName}`;
+    }
+
+    public httpUrl(): string {
+        return 'https://' + this.path();
+    }
+}

--- a/aws-infra/stage-of/lib/construct/ecs-cluster.ts
+++ b/aws-infra/stage-of/lib/construct/ecs-cluster.ts
@@ -15,6 +15,7 @@ import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { LoadBalancerTarget } from 'aws-cdk-lib/aws-route53-targets';
 import { CfnStage } from 'aws-cdk-lib/aws-apigatewayv2';
 import { ApiGatewayEndpoint } from './apigateway-endpoint';
+import { ParameterStore } from '../parameterstore/parameter-store';
 
 export interface EcsClusterProps {
     readonly context: Context;
@@ -168,7 +169,7 @@ export class EcsCluster extends Construct {
             })
         }
 
-        const certificateArn = StringParameter.valueFromLookup(this, context.certArnPraStoreName());
+        const certificateArn = new ParameterStore(props.context, this).cerificationArn();
         const certificate = ListenerCertificate.fromArn(certificateArn);
 
         albFargateService.loadBalancer.addListener('AlbListenerHTTPS', {
@@ -182,7 +183,7 @@ export class EcsCluster extends Construct {
     }
 
     private buildDnsRecord(alb: ApplicationLoadBalancer, context: Context): void {
-        const hostedZoneId = StringParameter.valueFromLookup(this, context.hostedZoneIdPraStoreName());
+        const hostedZoneId = new ParameterStore(context, this).hostedZoneId();
         const hostedZone = HostedZone.fromHostedZoneAttributes(this, "HostZone", {
             zoneName: context.applicationDnsARecordName(),
             hostedZoneId: hostedZoneId,

--- a/aws-infra/stage-of/lib/context/context.ts
+++ b/aws-infra/stage-of/lib/context/context.ts
@@ -122,14 +122,6 @@ export class Context {
         return this.currentStage().apiFqdn + '.';
     }
 
-    public certArnPraStoreName(): string {
-        return `${this.systemName()}-certification-arn`;
-    }
-
-    public hostedZoneIdPraStoreName(): string {
-        return `${this.systemName()}-hostedzone-id`;
-    }
-
     public dynamoDbTableName(): string {
         return `${this.systemName()}_websocket_connections_${this.currentStageId}`;
     }

--- a/aws-infra/stage-of/lib/parameterstore/parameter-store.ts
+++ b/aws-infra/stage-of/lib/parameterstore/parameter-store.ts
@@ -1,0 +1,45 @@
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { Context } from '../context/context';
+
+export class ParameterStore {
+    constructor(
+        private readonly context: Context,
+        private readonly scope: Construct,
+    ) { }
+
+    public cerificationArn(): string {
+        return this.lookup(this.certArnPraStoreName());
+    }
+
+    public hostedZoneId(): string {
+        return this.lookup(this.hostedZoneIdPraStoreName());
+    }
+
+
+    public registerCerificationArn(value: string): void {
+        this.register(this.certArnPraStoreName(), value);
+    }
+
+    public registerHostedZoneId(value: string): void {
+        this.register(this.hostedZoneIdPraStoreName(), value);
+    }
+
+
+    public certArnPraStoreName(): string {
+        return `${this.context.systemName()}-certification-arn`;
+    }
+
+    public hostedZoneIdPraStoreName(): string {
+        return `${this.context.systemName()}-hostedzone-id`;
+    }
+
+
+    private lookup(parameterName: string): string {
+        return StringParameter.valueFromLookup(this.scope, parameterName);
+    }
+
+    private register(parameterName: string, value: string): StringParameter {
+        return new StringParameter(this.scope, parameterName, { stringValue: value });
+    }
+}

--- a/aws-infra/stage-of/package-lock.json
+++ b/aws-infra/stage-of/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "2.81.0",
-        "constructs": "^10.0.0",
+        "constructs": "^10.2.36",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.1",
-        "@types/node": "20.1.7",
+        "@types/node": "20.2.5",
         "aws-cdk": "2.81.0",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0",
@@ -1124,9 +1124,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.1.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.7.tgz",
-      "integrity": "sha512-WCuw/o4GSwDGMoonES8rcvwsig77dGCMbZDrZr2x4ZZiNW4P/gcoZXe/0twgtobcTkmg9TuKflxYL/DuwDyJzg==",
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1693,12 +1693,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1909,7 +1911,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/constructs": {
       "version": "10.2.36",
@@ -3228,6 +3231,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3566,6 +3570,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }


### PR DESCRIPTION
カスタムドメインが登録できない(Certifiateを登録できない)という問題があるので、一時的に「環境変数に生のURL(ApiGatewayが自動的につくるやつ)を保持する」ようにする。

また、 `ParameterStore` を「一元的に取得・保存する」クラスを定義して使うよう、リファクタリングする。