### PR TITLE
bugfix: デプロイ時の「JSON書き換え」をsedからjqコマンドへ変更

### DIFF
--- a/cd/deploy/buildspec.yml
+++ b/cd/deploy/buildspec.yml
@@ -16,7 +16,7 @@ phases:
     commands:
       - ${CD_DIR}/migration_cdk.sh ${VERSION_TAG}
       - ${CD_DIR}/deploy_ecs.sh ${VERSION_TAG}
-      - ${CD_DIR}/deploy_lambda.sh ${VERSION_TAG}
+      # - ${CD_DIR}/deploy_lambda.sh ${VERSION_TAG}
 
   post_build:
     commands:

--- a/cd/deploy/buildspec.yml
+++ b/cd/deploy/buildspec.yml
@@ -16,7 +16,7 @@ phases:
     commands:
       - ${CD_DIR}/migration_cdk.sh ${VERSION_TAG}
       - ${CD_DIR}/deploy_ecs.sh ${VERSION_TAG}
-      # - ${CD_DIR}/deploy_lambda.sh ${VERSION_TAG}
+      - ${CD_DIR}/deploy_lambda.sh ${VERSION_TAG}
 
   post_build:
     commands:

--- a/cd/deploy/deploy_ecs.sh
+++ b/cd/deploy/deploy_ecs.sh
@@ -19,7 +19,16 @@ aws ecs describe-task-definition --task-definition ${ECS_TASK_FAMILY} | \
     jq '.taskDefinition | del (.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' \
     > ./taskdef.json
 
+echo '-------- 変更前 taskdef.json begin --------'
+cat ./taskdef.json
+echo '-------- 変更前 taskdef.json end   --------'
+
 sed -i "s/\"image\": .*\",/\"image\": \"${CONTAINER_REGISTRY_TAG_URI}\",/g" ./taskdef.json
+
+
+echo '-------- 変更後 taskdef.json begin --------'
+cat ./taskdef.json
+echo '-------- 変更後 taskdef.json end   --------'
 
 # TDOO ECSにコンテナがあるかどうかをチェックして、なかったら殺す。
 

--- a/cd/deploy/deploy_ecs.sh
+++ b/cd/deploy/deploy_ecs.sh
@@ -19,20 +19,15 @@ aws ecs describe-task-definition --task-definition ${ECS_TASK_FAMILY} | \
     jq '.taskDefinition | del (.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' \
     > ./taskdef.json
 
-echo '-------- 変更前 taskdef.json begin --------'
-cat ./taskdef.json
-echo '-------- 変更前 taskdef.json end   --------'
-
-sed -i "s/\"image\": .*\",/\"image\": \"${CONTAINER_REGISTRY_TAG_URI}\",/g" ./taskdef.json
-
+jq ".containerDefinitions[0].image=\"${CONTAINER_REGISTRY_TAG_URI}\"" ./taskdef.json > ./overwrited.json
 
 echo '-------- 変更後 taskdef.json begin --------'
-cat ./taskdef.json
+cat ./overwrited.json
 echo '-------- 変更後 taskdef.json end   --------'
 
 # TDOO ECSにコンテナがあるかどうかをチェックして、なかったら殺す。
 
-aws ecs register-task-definition --cli-input-json file://taskdef.json > ./register-result.json
+aws ecs register-task-definition --cli-input-json file://overwrited.json > ./register-result.json
 aws ecs update-service --cluster ${ECS_CLUSTER} \
     --service ${ECS_SERVICE} \
     --task-definition ${ECS_TASK_FAMILY}

--- a/doc/aws/ECS_TRYANDERROR.md
+++ b/doc/aws/ECS_TRYANDERROR.md
@@ -68,6 +68,14 @@
 - https://dev.classmethod.jp/articles/alb-vpc-lambda-sample-cdk/
   - これはLambdaの例だが、ALB周りの知識として
 
+## デプロイ方法が「JSON取って書き換えて投げ込む」で良いのか？
+
+あるところから持ってきたやり方が「たまたま上手く行った」ので、探求していなかった。
+
+このやりかたは本当に「正しい」くて「一般的」なのか…わからないので情報を集める。
+
+- https://nulab.com/ja/blog/nulab/git-team-ecs-deploy/
+
 ## トラブルシュート:ECSからDynamoDBにアクセスするのに、IAMだけでよく、SecretKeyは要らない
 
 ローカルでテストするために、php+AWS-SDK+DynamoDBClientを使い「AccessKey/SecretKey」でアクセスしていた。


### PR DESCRIPTION
原因を特定はできていないが「デプロイ出来ない時」がある。

万が一 `image` パーツが無い場合にも、新たに作って上書きするように変更する。

それに「正規表現では不安定」に思えるので、「餅は餅屋」で専門コマンドにやらせていたほうが安定するだろう、という目論見。